### PR TITLE
use std::make_tuple to prevent build errors from older versions of gcc

### DIFF
--- a/envmap.h
+++ b/envmap.h
@@ -28,9 +28,9 @@ struct EnvironmentMap {
           pdf_norm((Real)pdf_norm) {}
 
     inline std::tuple<int, int, int> get_size() const {
-        return {values.width,
+        return std::make_tuple(values.width,
                 values.height,
-                values.num_levels};
+                values.num_levels);
     }
 
     Texture3 values;


### PR DESCRIPTION
addresses #18 

tested on ubuntu with gcc 5