### PR TITLE
Enable different sampling rates for forward and backward pass

### DIFF
--- a/redner.cpp
+++ b/redner.cpp
@@ -140,7 +140,8 @@ PYBIND11_MODULE(redner, m) {
                       int,
                       int,
                       std::vector<Channels>>())
-        .def_readwrite("seed", &RenderOptions::seed);
+        .def_readwrite("seed", &RenderOptions::seed)
+        .def_readwrite("num_samples", &RenderOptions::num_samples);
 
     py::class_<Vector2f>(m, "Vector2f")
         .def_readwrite("x", &Vector2f::x)


### PR DESCRIPTION
It's often useful to have different MC sampling rates for forward and backward passes of the renderer. This change allows for the user to specify the forward and backward pass sampling rates to be different by passing in a tuple of two integers instead of a single integer.