### PR TITLE
Enable serializing and deserializing python primitives

### DIFF
--- a/pyredner/envmap.py
+++ b/pyredner/envmap.py
@@ -15,6 +15,8 @@ class EnvironmentMap:
         else:
             assert(not values.texels.is_cuda)
 
+        assert(env_to_world.dtype == torch.float32)
+
         # Build sampling table
         luminance = 0.212671 * values.texels[:, :, 0] + \
                     0.715160 * values.texels[:, :, 1] + \
@@ -43,3 +45,25 @@ class EnvironmentMap:
         self.sample_cdf_xs = sample_cdf_xs.contiguous()
         self.pdf_norm = pdf_norm
 
+    def state_dict(self):
+        return {
+            'values': self.values.state_dict(),
+            'env_to_world': self.env_to_world.cpu(),
+            'world_to_env': self.world_to_env.cpu(),
+            'sample_cdf_ys': self.sample_cdf_ys.cpu(),
+            'sample_cdf_xs': self.sample_cdf_xs.cpu(),
+            'pdf_norm': self.pdf_norm.cpu(),
+        }
+
+    @classmethod
+    def load_state_dict(cls, state_dict):
+        # TODO: should be a better way to do this
+        out = cls(torch.tensor([0.0,0.0,0.0]))
+        out.values = pyredner.Texture.load_state_dict(state_dict['values'])
+        out.env_to_world = state_dict['env_to_world']
+        out.world_to_env = state_dict['world_to_env']
+        out.sample_cdf_ys = state_dict['sample_cdf_ys']
+        out.sample_cdf_xs = state_dict['sample_cdf_xs']
+        out.pdf_norm = state_dict['pdf_norm']
+
+        return out

--- a/pyredner/material.py
+++ b/pyredner/material.py
@@ -41,3 +41,20 @@ class Material:
         self.specular_reflectance = specular_reflectance
         self.roughness = roughness
         self.two_sided = two_sided
+
+    def state_dict(self):
+        return {
+            'diffuse_reflectance': self.diffuse_reflectance.state_dict(),
+            'specular_reflectance': self.specular_reflectance.state_dict(),
+            'roughness': self.roughness.state_dict(),
+            'two_sided': self.two_sided,
+        }
+
+    @classmethod
+    def load_state_dict(cls, state_dict):
+        out = cls(
+            pyredner.Texture.load_state_dict(state_dict['diffuse_reflectance']),
+            pyredner.Texture.load_state_dict(state_dict['specular_reflectance']),
+            pyredner.Texture.load_state_dict(state_dict['roughness']),
+            state_dict['two_sided'])
+        return out

--- a/pyredner/shape.py
+++ b/pyredner/shape.py
@@ -69,3 +69,23 @@ class Shape:
         self.normals = normals
         self.material_id = material_id
         self.light_id = -1
+
+    def state_dict(self):
+        return {
+            'vertices': self.vertices.cpu(),
+            'indices': self.indices.cpu(),
+            'uvs': self.uvs.cpu(),
+            'normals': self.normals.cpu(),
+            'material_id': self.material_id,
+            'light_id': self.light_id,
+        }
+
+    @classmethod
+    def load_state_dict(cls, state_dict):
+        out = cls(
+            state_dict['vertices'],
+            state_dict['indices'],
+            state_dict['uvs'],
+            state_dict['normals'],
+            state_dict['material_id'])
+        return out

--- a/pyredner/texture.py
+++ b/pyredner/texture.py
@@ -50,3 +50,18 @@ class Texture:
 
         self.mipmap = texels
         self.uv_scale = uv_scale
+
+    def state_dict(self):
+        return {
+            'texels': self.texels.cpu(),
+            'mipmap': self.mipmap.cpu(),
+            'uv_scale': self.uv_scale.cpu()
+        }
+    @classmethod
+    def load_state_dict(cls, state_dict):
+        # TODO: should be a better way to do this
+        out = cls(torch.tensor([0.0, 0.0, 0.0]))
+        out.texels = state_dict['texels']
+        out.mipmap = state_dict['mipmap']
+        out.uv_scale = state_dict['uv_scale'].to(torch.device('cpu'))
+        return out


### PR DESCRIPTION
When attempting to train large models with a large memory footprint, it's often infeasible to fit every pyredner primitive onto GPU memory. One method of dealing with this issue is to serialize all pyredner primitives offline as a pytorch pickle (.pth format) and load it into memory at each iteration of training at runtime. These helper methods enable serialization and deserialization s.t. we're able to use the torch.save and torch.load functions from pytorch.

I should note though that some of the ways we deal with instantiating class member objects aren't ideal and should be iterated upon before pushing. I'm also in the middle of looking at how storing and loading tensors that were on different devices is treated by pytorch. For now, I've simply made sure that all tensors are on cpu() when they are serialized.