### PR TITLE
Add tensorflow `save_obj` and performance improvments

### DIFF
--- a/pyredner/save_obj.py
+++ b/pyredner/save_obj.py
@@ -1,4 +1,3 @@
-import torch
 import pyredner
 from typing import Union
 
@@ -18,9 +17,9 @@ def save_obj(shape: Union[pyredner.Object, pyredner.Shape],
             flip the v coordinate of uv by applying v' = 1 - v
     """
     with open(filename, 'w') as f:
-        vertices = shape.vertices.cpu()
-        uvs = shape.uvs.cpu() if shape.uvs is not None else None
-        normals = shape.normals.cpu() if shape.normals is not None else None
+        vertices = shape.vertices.cpu().numpy()
+        uvs = shape.uvs.cpu().numpy() if shape.uvs is not None else None
+        normals = shape.normals.cpu().numpy() if shape.normals is not None else None
         for i in range(vertices.shape[0]):
             f.write('v {} {} {}\n'.format(vertices[i, 0], vertices[i, 1], vertices[i, 2]))
         if uvs is not None:
@@ -32,9 +31,9 @@ def save_obj(shape: Union[pyredner.Object, pyredner.Shape],
         if normals is not None:
             for i in range(normals.shape[0]):
                 f.write('vn {} {} {}\n'.format(normals[i, 0], normals[i, 1], normals[i, 2]))
-        indices = shape.indices.cpu() + 1
-        uv_indices = shape.uv_indices.cpu() + 1 if shape.uv_indices is not None else None
-        normal_indices = shape.normal_indices.cpu() + 1 if shape.normal_indices is not None else None
+        indices = shape.indices.cpu().numpy() + 1
+        uv_indices = shape.uv_indices.cpu().numpy() + 1 if shape.uv_indices is not None else None
+        normal_indices = shape.normal_indices.cpu().numpy() + 1 if shape.normal_indices is not None else None
         for i in range(indices.shape[0]):
             vi = (indices[i, 0], indices[i, 1], indices[i, 2])
             if uv_indices is not None:

--- a/pyredner_tensorflow/__init__.py
+++ b/pyredner_tensorflow/__init__.py
@@ -17,6 +17,7 @@ from .envmap import *
 from .scene import *
 from .image import *
 from .load_obj import load_obj
+from .save_obj import save_obj
 from .load_mitsuba import load_mitsuba
 from .transform import *
 from .utils import *

--- a/pyredner_tensorflow/save_obj.py
+++ b/pyredner_tensorflow/save_obj.py
@@ -1,0 +1,67 @@
+import pyredner_tensorflow as pyredner
+from typing import Union
+
+def save_obj(shape: Union[pyredner.Object, pyredner.Shape],
+             filename: str,
+             flip_tex_coords = True):
+    """
+        Save to a Wavefront obj file from an Object or a Shape.
+
+        Args
+        ====
+        shape: Union[pyredner.Object, pyredner.Shape]
+
+        filename: str
+
+        flip_tex_coords: bool
+            flip the v coordinate of uv by applying v' = 1 - v
+    """
+    with open(filename, 'w') as f:
+        vertices = shape.vertices.numpy()
+        uvs = shape.uvs.numpy() if shape.uvs is not None else None
+        normals = shape.normals.numpy() if shape.normals is not None else None
+        for i in range(vertices.shape[0]):
+            f.write('v {} {} {}\n'.format(vertices[i, 0], vertices[i, 1], vertices[i, 2]))
+        if uvs is not None:
+            for i in range(uvs.shape[0]):
+                if flip_tex_coords:
+                    f.write('vt {} {}\n'.format(uvs[i, 0], 1 - uvs[i, 1]))
+                else:
+                    f.write('vt {} {}\n'.format(uvs[i, 0], uvs[i, 1]))
+        if normals is not None:
+            for i in range(normals.shape[0]):
+                f.write('vn {} {} {}\n'.format(normals[i, 0], normals[i, 1], normals[i, 2]))
+        indices = shape.indices.numpy() + 1
+        uv_indices = shape.uv_indices.numpy() + 1 if shape.uv_indices is not None else None
+        normal_indices = shape.normal_indices.numpy() + 1 if shape.normal_indices is not None else None
+        for i in range(indices.shape[0]):
+            vi = (indices[i, 0], indices[i, 1], indices[i, 2])
+            if uv_indices is not None:
+                uvi = (uv_indices[i, 0], uv_indices[i, 1], uv_indices[i, 2])
+            else:
+                if uvs is not None:
+                    uvi = vi
+                else:
+                    uvi = ''
+            if normal_indices is not None:
+                ni = (normal_indices[i, 0], normal_indices[i, 1], normal_indices[i, 2])
+            else:
+                if normals is not None:
+                    ni = vi
+                else:
+                    ni = ''
+            if normals is not None:
+                f.write('f {}/{}/{} {}/{}/{} {}/{}/{}\n'.format(\
+                    vi[0], uvi[0], ni[0],
+                    vi[1], uvi[1], ni[1],
+                    vi[2], uvi[2], ni[2]))
+            elif uvs is not None:
+                f.write('f {}/{} {}/{} {}/{}\n'.format(\
+                    vi[0], uvi[0],
+                    vi[1], uvi[1],
+                    vi[2], uvi[2]))
+            else:
+                f.write('f {} {} {}\n'.format(\
+                    vi[0],
+                    vi[1],
+                    vi[2]))

--- a/tests_tensorflow/test_save_obj.py
+++ b/tests_tensorflow/test_save_obj.py
@@ -1,0 +1,21 @@
+# Tensorflow by default allocates all GPU memory, leaving very little for rendering.
+# We set the environment variable TF_FORCE_GPU_ALLOW_GROWTH to true to enforce on demand
+# memory allocation to reduce page faults.
+import os
+os.environ['TF_FORCE_GPU_ALLOW_GROWTH'] = 'true'
+import tensorflow as tf
+tf.compat.v1.enable_eager_execution()
+import pyredner_tensorflow as pyredner
+
+vertices, indices, uvs, normals = pyredner.generate_sphere(16, 32)
+m = pyredner.Material(diffuse_reflectance = tf.constant((0.5, 0.5, 0.5)))
+obj = pyredner.Object(vertices = vertices,
+                      indices = indices,
+                      uvs = uvs,
+                      normals = normals,
+                      material = m)
+filename = 'results/test_save_obj/sphere.obj'
+directory = os.path.dirname(filename)
+if directory != '' and not os.path.exists(directory):
+    os.makedirs(directory)
+pyredner.save_obj(obj, 'results/test_save_obj/sphere.obj')


### PR DESCRIPTION
1. Add missing `save_obj` in tensorflow
2. Improve performance of PyTorch `save_obj` by using numpy arrays
  Object: `pyredner.generate_sphere(128, 256)`
  GPU: Titan X (Pascal)
  Timings:
  `.cpu()`: 2.46s
  `.cpu().numpy()`: 0.463s