### PR TITLE
Add getter and setter for print_timing flag

### DIFF
--- a/pyredner/render_pytorch.py
+++ b/pyredner/render_pytorch.py
@@ -28,6 +28,19 @@ def get_use_correlated_random_number():
     return use_correlated_random_number
 
 print_timing = True
+def set_print_timing(v: bool):
+    """
+        Set whether to print time measurements or not.
+    """
+    global print_timing
+    print_timing = v
+
+def get_print_timing():
+    """
+        Get whether we print time measurements or not.
+    """
+    global print_timing
+    return print_timing
 
 def serialize_texture(texture, args):
     if texture is None:
@@ -544,7 +557,7 @@ class RenderFunction(torch.autograd.Function):
                              use_primary_edge_sampling,
                              use_secondary_edge_sampling)
         time_elapsed = time.time() - start
-        if print_timing:
+        if get_print_timing():
             print('Scene construction, time: %.5f s' % time_elapsed)
 
         # check that num_samples is a tuple
@@ -607,7 +620,7 @@ class RenderFunction(torch.autograd.Function):
                       redner.float_ptr(0), # translational_gradient_image
                       redner.float_ptr(0)) # debug_image
         time_elapsed = time.time() - start
-        if print_timing:
+        if get_print_timing():
             print('Forward pass, time: %.5f s' % time_elapsed)
 
         ctx.camera = camera
@@ -948,7 +961,7 @@ class RenderFunction(torch.autograd.Function):
                       redner.float_ptr(screen_gradient_image.data_ptr()),
                       redner.float_ptr(0)) # debug_image
         time_elapsed = time.time() - start
-        if print_timing:
+        if get_print_timing():
             print('Visualize gradient, time: %.5f s' % time_elapsed)
 
         return screen_gradient_image
@@ -977,7 +990,7 @@ class RenderFunction(torch.autograd.Function):
                       redner.float_ptr(0), # translational_gradient_image
                       redner.float_ptr(0)) # debug_image
         time_elapsed = time.time() - start
-        if print_timing:
+        if get_print_timing():
             print('Backward pass, time: %.5f s' % time_elapsed)
 
         ret_list = []

--- a/pyredner_tensorflow/render_tensorflow.py
+++ b/pyredner_tensorflow/render_tensorflow.py
@@ -45,6 +45,19 @@ def is_empty_tensor(tensor):
 class Context: pass
 
 print_timing = True
+def set_print_timing(v: bool):
+    """
+        Set whether to print time measurements or not.
+    """
+    global print_timing
+    print_timing = v
+
+def get_print_timing():
+    """
+        Get whether we print time measurements or not.
+    """
+    global print_timing
+    return print_timing
 
 def serialize_texture(texture, args):
     if texture is None:
@@ -563,7 +576,7 @@ def unpack_args(seed,
                          use_primary_edge_sampling,
                          use_secondary_edge_sampling)
     time_elapsed = time.time() - start
-    if print_timing:
+    if get_print_timing():
         print('Scene construction, time: %.5f s' % time_elapsed)
 
     # check that num_samples is a tuple
@@ -628,7 +641,7 @@ def forward(seed:int, *args):
                       redner.float_ptr(0), # translational_gradient_image
                       redner.float_ptr(0)) # debug_image
         time_elapsed = time.time() - start
-        if print_timing:
+        if get_print_timing():
             print('Forward pass, time: %.5f s' % time_elapsed)
 
     ctx = Context()
@@ -958,7 +971,7 @@ def render(*x):
                           redner.float_ptr(0)) # debug_image
         time_elapsed = time.time() - start
 
-        if print_timing:
+        if get_print_timing():
             print('Backward pass, time: %.5f s' % time_elapsed)
 
         ret_list = []
@@ -1127,7 +1140,7 @@ def visualize_screen_gradient(grad_img: tf.Tensor,
                       redner.float_ptr(pyredner.data_ptr(screen_gradient_image)),
                       redner.float_ptr(0)) # debug_image
         time_elapsed = time.time() - start
-    if print_timing:
+    if get_print_timing():
         print('Visualize gradient, time: %.5f s' % time_elapsed)
 
     return screen_gradient_image


### PR DESCRIPTION
This PR adds getters and setters for the `print_timing` flag, inspired by those for the flags `use_gpu` etc. In scenarios where a lot of rendering and backpropagation is going on, the timing debug outputs can pollute the stdout and it's therefore nice to be able to turn them off.