### PR TITLE
Fix missing stdexcept include

### DIFF
--- a/channels.cpp
+++ b/channels.cpp
@@ -1,6 +1,7 @@
 #include "channels.h"
 #include "cuda_utils.h"
 #include <iostream>
+#include <stdexcept>
 
 ChannelInfo::ChannelInfo(const std::vector<Channels> &channels,
                          bool use_gpu,


### PR DESCRIPTION
This PR fixes the missing include of `<stdexcept>` in `channels.cpp`. It caused an error when I tried to compile with gcc 4.8.5.