### PR TITLE
Adding option to make generated quad light invisible to camera during rendering

### DIFF
--- a/pyredner/area_light.py
+++ b/pyredner/area_light.py
@@ -13,7 +13,7 @@ class AreaLight:
         two_sided: bool
             Is the light emitting light from the two sides of the faces?
         directly_visible: bool
-            Can the camera sees the light source directly?
+            Can the camera see the light source directly?
     """
 
     def __init__(self,

--- a/pyredner/object.py
+++ b/pyredner/object.py
@@ -47,6 +47,9 @@ class Object:
         colors: Optional[torch.Tensor]
             optional per-vertex color
             float32 tensor with size num_vertices x 3
+        directly_visible: Optional[bool]
+            optional setting to see if object is visible to camera
+            during rendering.
     """
     def __init__(self,
                  vertices: torch.Tensor,
@@ -58,7 +61,8 @@ class Object:
                  normals: Optional[torch.Tensor] = None,
                  uv_indices: Optional[torch.Tensor] = None,
                  normal_indices: Optional[torch.Tensor] = None,
-                 colors: Optional[torch.Tensor] = None):
+                 colors: Optional[torch.Tensor] = None,
+                 directly_visible: Optional[bool] = None):
         self.vertices = vertices
         self.indices = indices
         self.uvs = uvs
@@ -69,3 +73,4 @@ class Object:
         self.material = material
         self.light_intensity = light_intensity
         self.light_two_sided = light_two_sided
+        self.directly_visible = directly_visible

--- a/pyredner/scene.py
+++ b/pyredner/scene.py
@@ -51,7 +51,8 @@ class Scene:
                     current_shape_id = len(shapes)
                     area_light = pyredner.AreaLight(shape_id = current_shape_id,
                                                     intensity = obj.light_intensity,
-                                                    two_sided = obj.light_two_sided)
+                                                    two_sided = obj.light_two_sided,
+                                                    directly_visible = obj.directly_visible)
                     area_lights.append(area_light)
                 shape = pyredner.Shape(vertices = obj.vertices,
                                        indices = obj.indices,

--- a/pyredner/utils.py
+++ b/pyredner/utils.py
@@ -159,7 +159,8 @@ def generate_sphere(theta_steps: int,
 def generate_quad_light(position: torch.Tensor,
                         look_at: torch.Tensor,
                         size: torch.Tensor,
-                        intensity: torch.Tensor):
+                        intensity: torch.Tensor,
+                        directly_visible: Optional[bool] = None):
     """
         Generate a pyredner.Object that is a quad light source.
 
@@ -173,6 +174,8 @@ def generate_quad_light(position: torch.Tensor,
             1-d tensor of size 2
         intensity: torch.Tensor
             1-d tensor of size 3
+        directly_visible: Optional[bool]
+            Can the camera see the light source directly?
 
         Returns
         =======
@@ -202,7 +205,8 @@ def generate_quad_light(position: torch.Tensor,
     return pyredner.Object(vertices = vertices,
                            indices = indices,
                            material = m,
-                           light_intensity = intensity)
+                           light_intensity = intensity,
+                           directly_visible = directly_visible)
 
 def linear_to_srgb(x):
     return torch.where(x <= 0.0031308, 12.92 * x, 1.055 * torch.pow(x, 1.0 / 2.4) - 0.055)


### PR DESCRIPTION
Added `directly_visible` flag to `pyredner.object` and `pyredner.utils.generate_quad_light()`