### PR TITLE
Fix roughness handling in obj loading

### DIFF
--- a/pyredner/load_obj.py
+++ b/pyredner/load_obj.py
@@ -193,7 +193,7 @@ def load_obj(filename: str,
                         roughness = torch.tensor([2.0 / (m.Ns + 2.0)],
                             dtype = torch.float32, device = device)
                     else:
-                        roughness = 2.0 / (pyredner.imread(m.map_Ks) + 2.0)
+                        roughness = 2.0 / (pyredner.imread(m.map_Ns) + 2.0)
                         roughness = roughness.to(device)
                     if m.Ke != (0.0, 0.0, 0.0):
                         light_map[mtl_name] = torch.tensor(m.Ke, dtype = torch.float32)

--- a/pyredner_tensorflow/load_obj.py
+++ b/pyredner_tensorflow/load_obj.py
@@ -183,7 +183,7 @@ def load_obj(filename: str,
                         roughness = tf.constant([2.0 / (m.Ns + 2.0)],
                             dtype = tf.float32)
                     else:
-                        roughness = 2.0 / (pyredner.imread(m.map_Ks) + 2.0)
+                        roughness = 2.0 / (pyredner.imread(m.map_Ns) + 2.0)
                     if m.Ke != (0.0, 0.0, 0.0):
                         light_map[mtl_name] = tf.constant(m.Ke, dtype = tf.float32)
                     material_map[mtl_name] = pyredner.Material(


### PR DESCRIPTION
The obj loader uses the specular albedo map for roughness (`map_Ks` instead of `map_Ns`). Probably just a typo and fixed with this PR.