### PR TITLE
fix res indices in SH_reconstruct

### DIFF
--- a/pyredner/utils.py
+++ b/pyredner/utils.py
@@ -56,7 +56,7 @@ def SH_reconstruct(coeffs, res):
             result = result + sh_factor.view(sh_factor.shape[0], sh_factor.shape[1], 1) * coeffs[:, i]
             i += 1
     result = torch.max(result,
-        torch.zeros(res[1], res[0], coeffs.shape[0], device = coeffs.device))
+        torch.zeros(res[0], res[1], coeffs.shape[0], device = coeffs.device))
     return result
 #######################################################################################
 


### PR DESCRIPTION
Rectangular envmaps could not be generated using `SH_reconstruct` (https://github.com/BachiLi/redner/blob/master/pyredner/utils.py#L44) because of a mismatch between 

```
result = torch.zeros(res[0], res[1], coeffs.shape[0], device = coeffs.device)
```
and

```
result = torch.max(result,
        torch.zeros(res[1], res[0], coeffs.shape[0], device = coeffs.device))
```