### PR TITLE
Edge tree change to fix performance penalty for meshes far from the origin

### DIFF
--- a/src/edge_tree.cpp
+++ b/src/edge_tree.cpp
@@ -764,7 +764,7 @@ EdgeTree::EdgeTree(bool use_gpu,
         thrust::transform_reduce, edge_ids.begin(), edge_ids.end(),
         id_to_edge_pt_sum{shapes.begin(), edges.begin()},
         Vector3{0, 0, 0}, sum_vec3{});
-    edge_pt_mean /= Real(edge_ids.size());
+    edge_pt_mean /= 2. * Real(edge_ids.size());
     auto edge_pt_mad = DISPATCH(use_gpu,
         thrust::transform_reduce, edge_ids.begin(), edge_ids.end(),
         id_to_edge_pt_abs{shapes.begin(), edges.begin(), edge_pt_mean},


### PR DESCRIPTION
   The intersection code uses edge billboards to find ray/edge intersections.
    The thickness of those billboards is calculated as 1% of the mean average distance of all edges.
    To do so, each edge is reduced to a single point.
    Rather than reducing each edge to a point by averaging the 2 end vertices (i.e. (v0+v1)/2), the current
    code simply adds them: v0+v1.
    This produces a global mean which is potentially outside the bounding box of the mesh and the distance
    of the mesh to the origin governs how far outside.
    Also as a result the mean average distance also depends on the distance of the mesh to the origin:
    the further away, the larger this value and the thicker the billboard.
    By using the average rather than the simple sum for each edge, we get a billboard thickness which
    is independent of the mesh position.