### PR TITLE
Ensure proper initialization of d_bsdf_v_uv variable

### DIFF
--- a/src/path_contribution.cpp
+++ b/src/path_contribution.cpp
@@ -355,7 +355,7 @@ struct d_path_contribs_accumulator {
                 // Initialize bsdf vertex derivatives
                 Vector3 d_bsdf_v_p[3] = {Vector3{0, 0, 0}, Vector3{0, 0, 0}, Vector3{0, 0, 0}};
                 Vector3 d_bsdf_v_n[3] = {Vector3{0, 0, 0}, Vector3{0, 0, 0}, Vector3{0, 0, 0}};
-                Vector2 d_bsdf_v_uv[3] = {Vector2{0, 0}, Vector2{0, 0}};
+                Vector2 d_bsdf_v_uv[3] = {Vector2{0, 0}, Vector2{0, 0}, Vector2{0, 0}};
                 Vector3 d_bsdf_v_c[3] = {Vector3{0, 0, 0}, Vector3{0, 0, 0}, Vector3{0, 0, 0}};
 
                 auto bsdf_val = bsdf(material, shading_point, wi, wo, min_rough);


### PR DESCRIPTION
Discovered this issue when tracking down random crashes in CPU mode and CUDA memory access errors in GPU mode. Although CUDA 10 didn't complain, when building and running optimization tests with CUDA 11 (particularly in debug mode), the lack of initialization would results in `nan` values appearing in the gradients returned by Redner, which would immediately invalidate the geometric data being optimized and cause failures in subsequent renders (usually showing up when attempting to build the edge tree).

Initializing all components of the `d_bsdf_v_uv` array eliminates the `nan` gradients and associated symptoms.