### PR TITLE
Small but important bug fix for environment map wrapping behavior.

### DIFF
--- a/src/envmap.h
+++ b/src/envmap.h
@@ -266,6 +266,15 @@ inline Real envmap_pdf(const EnvironmentMap &envmap, const Vector3 &dir) {
     auto yci = modulo(yfi + 1, h);
     auto dx = x - xfi;
     auto dy = y - yfi;
+    if (dx < 0)
+        dx += w;
+    if (dy < 0)
+        dy += h;
+    // Allowing dx and dy to be up to 1e-3 outside the 0-1 range is
+    // probably generous, but I don't want the assert to fail
+    // unnecessarily.
+    assert (dx > -1e-3 && dx < 1.0 + 1e-3);
+    assert (dy > -1e-3 && dy < 1.0 + 1e-3);
     auto texels = envmap.values.texels[0];
     auto lum_ff = luminance(
         Vector3f{texels[3 * (yfi * w + xfi) + 0],


### PR DESCRIPTION
In the envmap_pdf() lookup function, there's a place where a dx and a dy are computed and these are clearly supposed to be in the 0-1 range.  But the x and y can wrap around, leading to dx or dy being far outside that range.  I added a correction for that case.