### PR TITLE
Pass through directly_visible flag for area light sources.

### DIFF
--- a/pyredner_tensorflow/object.py
+++ b/pyredner_tensorflow/object.py
@@ -30,6 +30,8 @@ class Object:
             float32 tensor with size 3
         light_two_sided: boolean
             Does the light emit from two sides of the shape?
+        light_directly_visible: boolean
+            Can the camera see the light source directly?
         uvs: Optional[tf.Tensor]:
             optional texture coordinates.
             float32 tensor with size num_uvs x 2
@@ -54,6 +56,7 @@ class Object:
                  material: pyredner.Material,
                  light_intensity: Optional[tf.Tensor] = None,
                  light_two_sided: bool = False,
+                 light_directly_visible: bool = True,
                  uvs: Optional[tf.Tensor] = None,
                  normals: Optional[tf.Tensor] = None,
                  uv_indices: Optional[tf.Tensor] = None,
@@ -82,3 +85,4 @@ class Object:
         self.material = material
         self.light_intensity = light_intensity
         self.light_two_sided = light_two_sided
+        self.light_directly_visible = light_directly_visible

--- a/pyredner_tensorflow/scene.py
+++ b/pyredner_tensorflow/scene.py
@@ -49,7 +49,8 @@ class Scene:
                     current_shape_id = len(shapes)
                     area_light = pyredner.AreaLight(shape_id = current_shape_id,
                                                     intensity = obj.light_intensity,
-                                                    two_sided = obj.light_two_sided)
+                                                    two_sided = obj.light_two_sided,
+                                                    directly_visible = obj.light_directly_visible)
                     area_lights.append(area_light)
                 shape = pyredner.Shape(vertices = obj.vertices,
                                        indices = obj.indices,

--- a/pyredner_tensorflow/utils.py
+++ b/pyredner_tensorflow/utils.py
@@ -152,7 +152,9 @@ def generate_sphere(theta_steps: int,
 def generate_quad_light(position: tf.Tensor,
                         look_at: tf.Tensor,
                         size: tf.Tensor,
-                        intensity: tf.Tensor):
+                        intensity: tf.Tensor,
+                        two_sided: bool = False,
+                        directly_visible: bool = True):
     """
         Generate a pyredner.Object that is a quad light source.
 
@@ -194,7 +196,9 @@ def generate_quad_light(position: tf.Tensor,
     return pyredner.Object(vertices = vertices,
                            indices = indices,
                            material = m,
-                           light_intensity = intensity)
+                           light_intensity = intensity,
+                           light_two_sided = two_sided,
+                           light_directly_visible = directly_visible)
 
 ############################################3
 def read_tensor(filename, shape):


### PR DESCRIPTION
I encountered problems where derivatives involving lighting seemed to not be computed correctly, and I don't remember the details, nor did I ever really understand what was going on.  But I did narrow things down to a point where I realized that turning off direct visibility for the area light source in my test scene would avoid the bad behavior that I was seeing.  But I also noticed that I couldn't turn off direct visibility for area lights as I could for other types of lights, even though the flag existed at a lower level.  So this change simply passes a directly_visible flag thru from the external API.  Of course, it would be great to actually fix the bad behavior that I was originally seeing for which this is a workaround, but having this flag is a good thing in any case, I'd think.  I think I could reproduce that original bad behavior, but I don't think I'd have the ability to fix it.  If you'd be interested in having a repro test case, we could talk.