### PR TITLE
Added a "directly_visible" flag to the pyredner_tensorflow object base class, and also to the "generate_quad_light" function.

### DIFF
--- a/pyredner/object.py
+++ b/pyredner/object.py
@@ -47,7 +47,7 @@ class Object:
         colors: Optional[torch.Tensor]
             optional per-vertex color
             float32 tensor with size num_vertices x 3
-        directly_visible: Optional[bool]
+        directly_visible: boolean
             optional setting to see if object is visible to camera
             during rendering.
     """
@@ -62,7 +62,7 @@ class Object:
                  uv_indices: Optional[torch.Tensor] = None,
                  normal_indices: Optional[torch.Tensor] = None,
                  colors: Optional[torch.Tensor] = None,
-                 directly_visible: Optional[bool] = None):
+                 directly_visible: bool = True):
         self.vertices = vertices
         self.indices = indices
         self.uvs = uvs

--- a/pyredner/utils.py
+++ b/pyredner/utils.py
@@ -160,7 +160,7 @@ def generate_quad_light(position: torch.Tensor,
                         look_at: torch.Tensor,
                         size: torch.Tensor,
                         intensity: torch.Tensor,
-                        directly_visible: Optional[bool] = None):
+                        directly_visible: bool = True):
     """
         Generate a pyredner.Object that is a quad light source.
 
@@ -174,7 +174,7 @@ def generate_quad_light(position: torch.Tensor,
             1-d tensor of size 2
         intensity: torch.Tensor
             1-d tensor of size 3
-        directly_visible: Optional[bool]
+        directly_visible: boolean
             Can the camera see the light source directly?
 
         Returns

--- a/pyredner_tensorflow/object.py
+++ b/pyredner_tensorflow/object.py
@@ -47,6 +47,9 @@ class Object:
         colors: Optional[tf.Tensor]
             optional per-vertex color
             float32 tensor with size num_vertices x 3
+        directly_visible: boolean
+            optional setting to see if object is visible to camera
+            during rendering.
     """
     def __init__(self,
                  vertices: tf.Tensor,
@@ -58,7 +61,8 @@ class Object:
                  normals: Optional[tf.Tensor] = None,
                  uv_indices: Optional[tf.Tensor] = None,
                  normal_indices: Optional[tf.Tensor] = None,
-                 colors: Optional[tf.Tensor] = None):
+                 colors: Optional[tf.Tensor] = None,
+                 directly_visible: bool = True):
         assert(vertices.dtype == tf.float32)
         assert(indices.dtype == tf.int32)
         if uvs is not None:
@@ -82,3 +86,4 @@ class Object:
         self.material = material
         self.light_intensity = light_intensity
         self.light_two_sided = light_two_sided
+        self.directly_visible = directly_visible

--- a/pyredner_tensorflow/scene.py
+++ b/pyredner_tensorflow/scene.py
@@ -49,7 +49,8 @@ class Scene:
                     current_shape_id = len(shapes)
                     area_light = pyredner.AreaLight(shape_id = current_shape_id,
                                                     intensity = obj.light_intensity,
-                                                    two_sided = obj.light_two_sided)
+                                                    two_sided = obj.light_two_sided,
+                                                    directly_visible = obj.directly_visible)
                     area_lights.append(area_light)
                 shape = pyredner.Shape(vertices = obj.vertices,
                                        indices = obj.indices,

--- a/pyredner_tensorflow/utils.py
+++ b/pyredner_tensorflow/utils.py
@@ -152,7 +152,8 @@ def generate_sphere(theta_steps: int,
 def generate_quad_light(position: tf.Tensor,
                         look_at: tf.Tensor,
                         size: tf.Tensor,
-                        intensity: tf.Tensor):
+                        intensity: tf.Tensor,
+                        directly_visible: bool = True):
     """
         Generate a pyredner.Object that is a quad light source.
 
@@ -194,7 +195,8 @@ def generate_quad_light(position: tf.Tensor,
     return pyredner.Object(vertices = vertices,
                            indices = indices,
                            material = m,
-                           light_intensity = intensity)
+                           light_intensity = intensity,
+                           directly_visible = directly_visible)
 
 ############################################3
 def read_tensor(filename, shape):


### PR DESCRIPTION
This was previously there for pyredner (the pytorch implementation), so this is really just making pyredner_tensorflow
consistent with pyredner.  At the same time, I noticed that, in pyredner, the default value for this optional argument was
"None", which was not aligned with the default values in, for example, area_light.py and envmap.py.  In the interest of
consistency - although this changes the default behavior in pyredner (the default behavior for either pyredner or
pyredner_tensorflow must necessarily change, if we want them to be consistent) - I changed the default for
“directly_visible” to be “True” everywhere.  (If the change to the default behavior for pyredner is an issue, we’d
be happy to take a different approach.)